### PR TITLE
Drop orphan product directories during sync enforcement

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -166,6 +166,21 @@ jobs:
             fi
           done < <(find skills -type f -name SKILL.md)
 
+          # Drop top-level product directories with no SKILL.md anywhere
+          # inside. These show up as misleading empty/helper-only folders
+          # to anyone browsing the catalog (e.g. a product placeholder
+          # with just a README, or a product whose every skill was just
+          # dropped above).
+          for product_dir in skills/*/; do
+            product_dir="${product_dir%/}"
+            if [ -z "$(find "$product_dir" -type f -name SKILL.md -print -quit 2>/dev/null)" ]; then
+              product=$(basename "$product_dir")
+              echo "$product|$product_dir|(orphan — no skills inside)" >> "$dropped"
+              echo "  ✗ Dropping orphan $product_dir — no SKILL.md inside"
+              rm -rf "$product_dir"
+            fi
+          done
+
           # Mark any product with a dropped skill as "changed" so the PR
           # opens even when the only diff is a removed non-compliant skill.
           if [ -s "$dropped" ]; then


### PR DESCRIPTION
## Summary
- Extends the compliance enforcement step to also remove **top-level product directories under `skills/` that contain no `SKILL.md` anywhere inside**.
- Catches two cases that the per-skill check misses today:
  - Placeholder dirs (e.g. `video-search-and-summarization/` with only a README — no skills published upstream yet)
  - Product dirs whose every skill just got dropped for missing `skill.oms.sig` / `skill-card.md` (e.g. `Model-Optimizer/common/` left behind as a helper-only folder)
- Orphan drops show up in the sync PR body and `missing-compliance` tracking issue alongside per-skill drops, marked `(orphan — no skills inside)`.

## Why
After merging the compliance enforcement, the test repo's catalog ended up with three dirs: `cuopt/` (compliant), plus `Model-Optimizer/` and `video-search-and-summarization/` — both empty/helper-only. Anyone pulling skills would see misleading folders that contain nothing usable.

## Test plan
- [ ] Trigger the sync workflow via `workflow_dispatch` after merging
- [ ] Confirm `cuopt/` still syncs (has compliant skills)
- [ ] Confirm `Model-Optimizer/` is removed (only `common/` helpers, no `SKILL.md`)
- [ ] Confirm `video-search-and-summarization/` is removed (only README)
- [ ] Confirm orphan entries appear in the PR body and tracking issue with `(orphan — no skills inside)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)