### PR TITLE
docs(readme): show only products with verified skills + verification guide

### DIFF
--- a/.github/scripts/regenerate-readme.sh
+++ b/.github/scripts/regenerate-readme.sh
@@ -29,11 +29,34 @@ yq ea '[.] | {"components": .}' components.d/*.yml > "$CONFIG"
 
 sorted_indices=$(yq -r '.components | to_entries | sort_by(.value.name | downcase) | .[].key' "$CONFIG")
 
+# Only render components with at least one verified SKILL.md in the catalog.
+# Enforcement (sync workflow) removes non-compliant skills and orphan product
+# dirs before this script runs, so a zero count means the product currently
+# has no skill present in the repo that passes compliance.
+component_skill_count() {
+  local idx=$1
+  local total=0
+  while read -r catalog_dir; do
+    if [ -d "skills/$catalog_dir" ]; then
+      cnt=$(find "skills/$catalog_dir" -name SKILL.md -type f 2>/dev/null | wc -l | tr -d ' ')
+      total=$((total + cnt))
+    fi
+  done < <(yq -r ".components[$idx].skills[].catalog_dir" "$CONFIG")
+  echo "$total"
+}
+
+kept_indices=""
+for i in $sorted_indices; do
+  if [ "$(component_skill_count "$i")" -gt 0 ]; then
+    kept_indices="$kept_indices $i"
+  fi
+done
+
 # Available Skills table
 {
   echo "| Product | Description | Skills | Catalog | Source | Version |"
   echo "|---------|-------------|:------:|---------|--------|---------|"
-  for i in $sorted_indices; do
+  for i in $kept_indices; do
     name=$(yq -r ".components[$i].name" "$CONFIG")
     description=$(yq -r ".components[$i].description" "$CONFIG" | tr -d '\n' | sed 's/  */ /g; s/^ //; s/ $//')
     repo=$(yq -r ".components[$i].repo" "$CONFIG")
@@ -42,13 +65,7 @@ sorted_indices=$(yq -r '.components | to_entries | sort_by(.value.name | downcas
     primary_path=${primary_path%/}
     primary_catalog=$(yq -r ".components[$i].skills[0].catalog_dir" "$CONFIG")
 
-    skill_count=0
-    while read -r catalog_dir; do
-      if [ -d "skills/$catalog_dir" ]; then
-        cnt=$(find "skills/$catalog_dir" -name SKILL.md -type f 2>/dev/null | wc -l | tr -d ' ')
-        skill_count=$((skill_count + cnt))
-      fi
-    done < <(yq -r ".components[$i].skills[].catalog_dir" "$CONFIG")
+    skill_count=$(component_skill_count "$i")
 
     slug=$(echo "$name" | tr 'A-Z ' 'a-z-')
     version_cell="—"
@@ -68,7 +85,7 @@ sorted_indices=$(yq -r '.components | to_entries | sort_by(.value.name | downcas
 {
   echo "| Product | Issues | Discussions | Contributing | Security |"
   echo "|---------|--------|-------------|--------------|----------|"
-  for i in $sorted_indices; do
+  for i in $kept_indices; do
     name=$(yq -r ".components[$i].name" "$CONFIG")
     repo=$(yq -r ".components[$i].repo" "$CONFIG")
     ref=$(yq -r ".components[$i].ref // \"main\"" "$CONFIG")
@@ -127,4 +144,6 @@ awk -v skills_file=/tmp/skills-table.md -v help_file=/tmp/help-table.md '
 mv /tmp/README.md.new README.md
 rm -f /tmp/skills-table.md /tmp/help-table.md
 
-echo "Regenerated README tables for $(echo "$sorted_indices" | wc -l | tr -d ' ') components"
+total=$(echo "$sorted_indices" | wc -w | tr -d ' ')
+kept=$(echo "$kept_indices" | wc -w | tr -d ' ')
+echo "Regenerated README tables for $kept of $total components (filtered out $((total - kept)) with no verified skills)"

--- a/README.md
+++ b/README.md
@@ -98,22 +98,7 @@ For non-interactive installs, global installs, agent-specific installs, updates,
 | Product | Description | Skills | Catalog | Source | Version |
 |---------|-------------|:------:|---------|--------|---------|
 | **AIQ** | NVIDIA AI-Q Blueprint - deploy local AI-Q services and run shallow or deep research workflows as agent skills. | 2 | [`skills/aiq-research/`](skills/aiq-research) | [Source](https://github.com/NVIDIA-AI-Blueprints/aiq/tree/develop/skills/aiq-research) | [`66b009e`](https://github.com/NVIDIA-AI-Blueprints/aiq/commit/66b009e3b28219eb2a09910c347d84c0675c2028) · 2026-05-27 |
-| **CUDA-Q** | CUDA Quantum — onboarding guide for installation, test programs, GPU simulation, QPU hardware, and quantum applications. | 0 | [`skills/CUDA-Q/`](skills/CUDA-Q) | [Source](https://github.com/NVIDIA/cuda-quantum/tree/main/.claude/skills) | [`6e30b71`](https://github.com/NVIDIA/cuda-quantum/commit/6e30b716d33677d1b5e3c9616718a6698acca09b) · 2026-05-27 |
 | **cuOpt** | GPU-accelerated optimization — vehicle routing, linear programming, quadratic programming, installation, server deployment, and developer tools. | 12 | [`skills/cuopt/`](skills/cuopt) | [Source](https://github.com/NVIDIA/cuopt/tree/main/skills) | [`d415bb6`](https://github.com/NVIDIA/cuopt/commit/d415bb6447a86cd268e824ef64ac05dcbc140ca0) · 2026-05-27 |
-| **DALI** | GPU-accelerated data loading and processing with NVIDIA DALI. | 0 | [`skills/DALI/`](skills/DALI) | [Source](https://github.com/NVIDIA/DALI/tree/main/.agents/skills) | [`74dd2d0`](https://github.com/NVIDIA/DALI/commit/74dd2d0d39529b0ba220c1af54d5a4d6823235ae) · 2026-05-27 |
-| **DeepStream** | Agentic skills for guided DeepStream development. | 0 | [`skills/deepstream/`](skills/deepstream) | [Source](https://github.com/NVIDIA-AI-IOT/DeepStream_Coding_Agent/tree/main/skills) | [`703b4d6`](https://github.com/NVIDIA-AI-IOT/DeepStream_Coding_Agent/commit/703b4d6b43c0ac02b37704c8929a81b5d6bd69f7) · 2026-05-14 |
-| **Megatron-Bridge** | Bridge between NeMo and Megatron — data processing, model conversion, and training utilities. | 0 | [`skills/Megatron-Bridge/`](skills/Megatron-Bridge) | [Source](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/skills) | [`4cc182b`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/commit/4cc182bf5bf318c2a086cf9b8a0f68c6a28f5914) · 2026-05-27 |
-| **Megatron-Core** | Large-scale distributed training — model parallelism, pipeline parallelism, and mixed precision. | 0 | [`skills/Megatron-Core/`](skills/Megatron-Core) | [Source](https://github.com/NVIDIA/Megatron-LM/tree/main/skills) | [`286445c`](https://github.com/NVIDIA/Megatron-LM/commit/286445c28a272de060f83f3486219e1c7bf44d69) · 2026-05-27 |
-| **Model-Optimizer** | Model optimization — quantization, sparsity, and distillation for efficient inference. | 0 | [`skills/Model-Optimizer/`](skills/Model-Optimizer) | [Source](https://github.com/NVIDIA/Model-Optimizer/tree/main/.claude/skills) | [`b49f9b9`](https://github.com/NVIDIA/Model-Optimizer/commit/b49f9b9e2d747af992d78a3aa7f10efe5a8847e1) · 2026-05-27 |
-| **NeMo Evaluator** | LLM evaluation — launch evaluations, access MLflow results, NeMo Evaluator Launcher assistant, and bring-your-own benchmarks. | 0 | [`skills/NeMo-Evaluator-Launcher/`](skills/NeMo-Evaluator-Launcher) | [Source](https://github.com/NVIDIA-NeMo/Evaluator/tree/main/packages/nemo-evaluator-launcher/.claude/skills) | [`2b7ce27`](https://github.com/NVIDIA-NeMo/Evaluator/commit/2b7ce27866ec8f73cfd3beefab71840a3520fd5c) · 2026-05-27 |
-| **NeMo Gym** | RL training environments — add benchmarks, resources servers, agent wiring, and reward profiling. | 0 | [`skills/NeMo-Gym/`](skills/NeMo-Gym) | [Source](https://github.com/NVIDIA-NeMo/Gym/tree/main/.claude/skills) | [`ff6f8d2`](https://github.com/NVIDIA-NeMo/Gym/commit/ff6f8d20ce26ddffbe6e64624487a1c69b652ec0) · 2026-05-27 |
-| **NeMo-RL** | RLHF training on Ray — GRPO, DPO, and SFT for LLMs and VLMs with FSDP2 and Megatron-Core. | 0 | [`skills/NeMo-RL/`](skills/NeMo-RL) | [Source](https://github.com/NVIDIA-NeMo/RL/tree/main/skills) | [`a1bf1ad`](https://github.com/NVIDIA-NeMo/RL/commit/a1bf1ad1f9ce714f2d15f11e1f50d8ab2193c1de) · 2026-05-27 |
-| **NemoClaw** | Secure agent sandboxing — run OpenClaw inside NVIDIA OpenShell with managed inference, policy management, remote deployment, sandbox monitoring, and contributor/maintainer workflows. | 0 | [`skills/NemoClaw/`](skills/NemoClaw) | [Source](https://github.com/NVIDIA/NemoClaw/tree/main/.agents/skills) | [`be6eefe`](https://github.com/NVIDIA/NemoClaw/commit/be6eefe7dd02a303dc43443f4bcd4216d6b49046) · 2026-05-27 |
-| **Nemotron Voice Agent** | Real-time conversational AI — deploy speech-to-speech voice agents on Workstation, Jetson Thor, or Cloud NIMs. | 0 | [`skills/nemotron-voice-agent/`](skills/nemotron-voice-agent) | [Source](https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent/tree/main/.agents/skills) | [`a87826c`](https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent/commit/a87826cc1ab03103cea7f1f24dc94f456500e5c2) · 2026-04-22 |
-| **RAG Blueprint** | RAG pipeline — deploy, configure, troubleshoot, and manage retrieval augmented generation with Docker Compose or Helm. | 0 | [`skills/rag/`](skills/rag) | [Source](https://github.com/NVIDIA-AI-Blueprints/rag/tree/main/skill-source/.agents/skills) | [`186f5b1`](https://github.com/NVIDIA-AI-Blueprints/rag/commit/186f5b1ba465cb90f15f0668eabfe911a29ab35b) · 2026-05-27 |
-| **TensorRT-LLM** | LLM inference optimization — model onboarding, performance analysis and optimization, kernel writing, CI diagnostics, code contribution, and codebase exploration. | 0 | [`skills/TensorRT-LLM/`](skills/TensorRT-LLM) | [Source](https://github.com/NVIDIA/TensorRT-LLM/tree/main/.claude/skills) | [`b1eb703`](https://github.com/NVIDIA/TensorRT-LLM/commit/b1eb703635647db24f35b0a8239fd4e2b775d5fc) · 2026-05-28 |
-| **TileGym** | Tile-based GPU programming — adding new kernels, cross-framework conversion, and performance optimization. | 0 | [`skills/TileGym/`](skills/TileGym) | [Source](https://github.com/NVIDIA/TileGym/tree/main/.agents/skills) | [`83cf1f4`](https://github.com/NVIDIA/TileGym/commit/83cf1f4b7c725468f8968d22a813c81e6111c6c3) · 2026-05-26 |
-| **Video Search and Summarization** | VSS Blueprint — deploy profiles, search and summarize video, generate analysis reports, manage alerts and incidents, query VIOS sensors, and use the RTVI VLM microservice. | 0 | [`skills/video-search-and-summarization/`](skills/video-search-and-summarization) | [Source](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/tree/main/skills) | [`d2067e3`](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/commit/d2067e3daa25f7c2011120ae46e7cfe5b512cabe) · 2026-05-27 |
 <!-- skills-table-end -->
 
 ---
@@ -126,25 +111,27 @@ For skill-related issues, feature requests, new skill ideas, discussions, and co
 | Product | Issues | Discussions | Contributing | Security |
 |---------|--------|-------------|--------------|----------|
 | **AIQ** | [Issues](https://github.com/NVIDIA-AI-Blueprints/aiq/issues) | [Discussions](https://github.com/NVIDIA-AI-Blueprints/aiq/discussions) | [Contributing](https://github.com/NVIDIA-AI-Blueprints/aiq/blob/develop/CONTRIBUTING.md) | [Security](https://github.com/NVIDIA-AI-Blueprints/aiq/blob/develop/SECURITY.md) |
-| **CUDA-Q** | [Issues](https://github.com/NVIDIA/cuda-quantum/issues) | [Discussions](https://github.com/NVIDIA/cuda-quantum/discussions) | [Contributing](https://github.com/NVIDIA/cuda-quantum/blob/main/Contributing.md) | [Security](https://github.com/NVIDIA/cuda-quantum/blob/main/SECURITY.md) |
 | **cuOpt** | [Issues](https://github.com/NVIDIA/cuopt/issues) | [Discussions](https://github.com/NVIDIA/cuopt/discussions) | [Contributing](https://github.com/NVIDIA/cuopt/blob/main/CONTRIBUTING.md) | [Security](https://github.com/NVIDIA/cuopt/blob/main/SECURITY.md) |
-| **DALI** | [Issues](https://github.com/NVIDIA/DALI/issues) | [Discussions](https://github.com/NVIDIA/DALI/discussions) | [Contributing](https://github.com/NVIDIA/DALI/blob/main/CONTRIBUTING.md) | [Security](https://github.com/NVIDIA/DALI/blob/main/SECURITY.md) |
-| **DeepStream** | [Issues](https://github.com/NVIDIA-AI-IOT/DeepStream_Coding_Agent/issues) | [Discussions](https://github.com/NVIDIA-AI-IOT/DeepStream_Coding_Agent/discussions) | [Contributing](https://github.com/NVIDIA-AI-IOT/DeepStream_Coding_Agent/blob/main/CONTRIBUTING.md) | [Security](https://github.com/NVIDIA-AI-IOT/DeepStream_Coding_Agent/blob/main/SECURITY.md) |
-| **Megatron-Bridge** | [Issues](https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues) | [Discussions](https://github.com/NVIDIA-NeMo/Megatron-Bridge/discussions) | [Contributing](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md) | [Security](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/SECURITY.md) |
-| **Megatron-Core** | [Issues](https://github.com/NVIDIA/Megatron-LM/issues) | [Discussions](https://github.com/NVIDIA/Megatron-LM/discussions) | [Contributing](https://github.com/NVIDIA/Megatron-LM/blob/main/CONTRIBUTING.md) | [Security](https://github.com/NVIDIA/Megatron-LM/blob/main/SECURITY.md) |
-| **Model-Optimizer** | [Issues](https://github.com/NVIDIA/Model-Optimizer/issues) | [Discussions](https://github.com/NVIDIA/Model-Optimizer/discussions) | [Contributing](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) | [Security](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md) |
-| **NeMo Evaluator** | [Issues](https://github.com/NVIDIA-NeMo/Evaluator/issues) | [Discussions](https://github.com/NVIDIA-NeMo/Evaluator/discussions) | [Contributing](https://github.com/NVIDIA-NeMo/Evaluator/blob/main/CONTRIBUTING.md) | [Security](https://github.com/NVIDIA-NeMo/Evaluator/blob/main/SECURITY.md) |
-| **NeMo Gym** | [Issues](https://github.com/NVIDIA-NeMo/Gym/issues) | [Discussions](https://github.com/NVIDIA-NeMo/Gym/discussions) | [Contributing](https://github.com/NVIDIA-NeMo/Gym/blob/main/CONTRIBUTING.md) | [Security](https://github.com/NVIDIA-NeMo/Gym/blob/main/SECURITY.md) |
-| **NeMo-RL** | [Issues](https://github.com/NVIDIA-NeMo/RL/issues) | [Discussions](https://github.com/NVIDIA-NeMo/RL/discussions) | [Contributing](https://github.com/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md) | [Security](https://github.com/NVIDIA-NeMo/RL/blob/main/SECURITY.md) |
-| **NemoClaw** | [Issues](https://github.com/NVIDIA/NemoClaw/issues) | [Discussions](https://github.com/NVIDIA/NemoClaw/discussions) | [Contributing](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md) | [Security](https://github.com/NVIDIA/NemoClaw/blob/main/SECURITY.md) |
-| **Nemotron Voice Agent** | [Issues](https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent/issues) | [Discussions](https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent/discussions) | [Contributing](https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent/blob/main/CONTRIBUTING.md) | [Security](https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent/blob/main/SECURITY.md) |
-| **RAG Blueprint** | [Issues](https://github.com/NVIDIA-AI-Blueprints/rag/issues) | [Discussions](https://github.com/NVIDIA-AI-Blueprints/rag/discussions) | [Contributing](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/CONTRIBUTING.md) | [Security](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/SECURITY.md) |
-| **TensorRT-LLM** | [Issues](https://github.com/NVIDIA/TensorRT-LLM/issues) | [Discussions](https://github.com/NVIDIA/TensorRT-LLM/discussions) | [Contributing](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CONTRIBUTING.md) | [Security](https://github.com/NVIDIA/TensorRT-LLM/blob/main/SECURITY.md) |
-| **TileGym** | [Issues](https://github.com/NVIDIA/TileGym/issues) | [Discussions](https://github.com/NVIDIA/TileGym/discussions) | [Contributing](https://github.com/NVIDIA/TileGym/blob/main/CONTRIBUTING.md) | [Security](https://github.com/NVIDIA/TileGym/blob/main/SECURITY.md) |
-| **Video Search and Summarization** | [Issues](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/issues) | [Discussions](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/discussions) | [Contributing](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/main/CONTRIBUTING.md) | [Security](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/main/SECURITY.md) |
 <!-- help-table-end -->
 
 For issues with **this catalog repo itself** (README, structure, listing a new product): [open an issue here](../../issues).
+
+---
+
+## Verifying Skills
+
+Every published skill ships with a detached OMS signature (`skill.oms.sig`). The sync pipeline drops any skill missing `skill.oms.sig`, `skill-card.md`, or `evals.json` before publishing, so anything in the catalog has all three artifacts.
+
+Verify a skill against the NVIDIA trust anchor [`nv-agent-root-cert.pem`](nv-agent-root-cert.pem):
+
+```bash
+pip install model-signing
+model_signing verify certificate SKILL_DIR \
+  --signature SKILL_DIR/skill.oms.sig \
+  --certificate-chain nv-agent-root-cert.pem
+```
+
+See [Verify Signed Agent Skills](docs/signing-agent-skills.mdx) for signature layout, the trust pipeline, and policy options.
 
 ---
 
@@ -153,9 +140,9 @@ For issues with **this catalog repo itself** (README, structure, listing a new p
 - ✅ Public skills catalog with NVIDIA-verified skills across multiple products
 - ✅ Automated sync pipeline with skills mirrored from product repos daily
 - ✅ Security scanning for all published skills covering instruction safety and supply-chain integrity
-- 🔲 Skills signing so every published skill carries a verifiable NVIDIA signature
-- 🔲 Skills universal evaluation criteria and task-specific criteria
-- 🔲 Skill Card with machine-readable metadata for identity, provenance, quality, and behavioral boundaries
+- ✅ Skills signing so every published skill carries a verifiable NVIDIA signature
+- ✅ Skills universal evaluation criteria and task-specific criteria
+- ✅ Skill Card with machine-readable metadata for identity, provenance, quality, and behavioral boundaries
 - 🔲 Compliance gates before external publication
 - 🔲 Syndication to external marketplaces and MCP hubs
 


### PR DESCRIPTION
## Summary

Test-repo mirror of [NVIDIA/skills#104](https://github.com/NVIDIA/skills/pull/104).

- **Filter the README Skill Catalog and Getting Help tables** to only list components that have at least one `SKILL.md` present in `skills/`. After the sync pipeline removes non-compliant skills (missing `skill.oms.sig`, `skill-card.md`, or `evals.json`) and orphan product dirs, a zero count means nothing in the repo passes compliance — listing the product is misleading.
- **Add a "Verifying Skills" section** with the `model_signing verify` command and links to the trust anchor (`nv-agent-root-cert.pem`) and `docs/signing-agent-skills.mdx`.
- **Update the roadmap** — flip skills signing, skill cards, and evaluation criteria from planned to done now that the pipeline enforces all three artifacts.

> ⚠️ **Diff note:** this branch is based on `NVIDIA/skills@main`, which is ahead of `sayalinvidia/sayali-skills-test@main`. The PR diff therefore includes catch-up commits (AIQ registration, evals enforcement, sync #312f941) in addition to the 2-file README change. The README/script change itself is in commit `7237646`.

## Test plan

- [ ] `bash .github/scripts/regenerate-readme.sh` locally renders only components with verified skills.
- [ ] Confirm the "Verifying Skills" section renders correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)