### PR TITLE
fix(generator): handle YAML date objects in frontmatter serialization

### DIFF
--- a/.github/scripts/marketplace/generate-skill-metadata.py
+++ b/.github/scripts/marketplace/generate-skill-metadata.py
@@ -537,7 +537,7 @@ class _AIClient:
                 {"role": "system", "content": system},
                 {
                     "role": "user",
-                    "content": json.dumps(user, ensure_ascii=False),
+                    "content": json.dumps(user, ensure_ascii=False, default=str),
                 },
             ],
             "max_tokens": 512,


### PR DESCRIPTION
Fixes crash when a SKILL.md has a YAML date field (e.g. `reviewed: 2024-01-15`). PyYAML parses these as `datetime.date` objects; `json.dumps` fails without a `default` handler. Adding `default=str` fixes it.