### PR TITLE
feat(sync): auto-ping source-repo owners when skills are dropped

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -48,6 +48,7 @@ jobs:
           truncate -s 0 /tmp/failed-components.txt
           truncate -s 0 /tmp/sync-versions.txt
           truncate -s 0 /tmp/rsynced-skill-dirs.txt
+          truncate -s 0 /tmp/skill-source-map.txt
 
           # Aggregate per-component files into a single config so the
           # iteration loop below can index by position. The components.d/
@@ -110,6 +111,10 @@ jobs:
                 # step to scan only the dirs this run actually touched
                 # (nesting-safe; not derived by awk-extracting paths).
                 echo "skills/$catalog_dir" >> /tmp/rsynced-skill-dirs.txt
+                # Source map: catalog dir → source repo + path, used by the
+                # "Ping skill owners" step to resolve GitHub commit authors
+                # after the .tmp clones have been deleted.
+                echo "skills/$catalog_dir|$repo|$path" >> /tmp/skill-source-map.txt
                 echo "  ✓ $path → skills/$catalog_dir/"
               else
                 echo "  ⚠ $path empty or missing — skipping to preserve existing catalog"
@@ -329,6 +334,19 @@ jobs:
             done < "$dropped"
           fi
 
+      - name: Snapshot existing drop-tracker state
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Save the pre-update issue body so "Ping skill owners" can
+          # determine which drops are new this run vs already tracked.
+          # Writes {} on any failure so downstream steps degrade gracefully.
+          gh issue list --label missing-compliance --state open \
+            --json number,body --jq '.[0] // {}' --limit 1 \
+            > /tmp/pre-update-tracker.json 2>/dev/null \
+            || echo '{}' > /tmp/pre-update-tracker.json
+
       - name: Track dropped skills
         continue-on-error: true
         env:
@@ -483,6 +501,84 @@ jobs:
               [ -n "$a" ] && (gh issue edit "$new_num" --add-assignee "$a" || echo "  warn: could not assign '$a' to issue #$new_num")
             done
           fi
+
+      - name: Ping skill owners for new drops
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          dropped=/tmp/dropped-skills.txt
+          source_map=/tmp/skill-source-map.txt
+
+          # Nothing dropped or no source map → nothing to do.
+          [ -s "$dropped" ]    || exit 0
+          [ -s "$source_map" ] || exit 0
+
+          # Pre-update issue body tells us which skills were already tracked
+          # (and therefore already pinged) in a prior run. Only post a comment
+          # for skills that appear for the first time this run, so owners get
+          # one notification per new drop rather than one per sync cycle.
+          pre_body=$(jq -r '.body // ""' /tmp/pre-update-tracker.json 2>/dev/null || true)
+
+          # Get the current issue number (Track step just created or updated it).
+          issue_num=$(gh issue list --label missing-compliance --state open \
+                        --json number --jq '.[0].number // empty' --limit 1)
+          [ -n "$issue_num" ] || exit 0
+
+          new_lines=""
+          while IFS='|' read -r product dir reason; do
+            # Orphan product dirs have no source skill path — skip.
+            case "$reason" in orphan:*) continue ;; esac
+
+            # Already in the pre-update body → pinged in a prior run → skip.
+            if printf '%s' "$pre_body" | grep -qF "\`$dir\`"; then
+              continue
+            fi
+
+            # Resolve source repo + path via the map built during rsync.
+            src_line=$(awk -F'|' -v d="$dir" '$1 == d {print; exit}' "$source_map" || true)
+            [ -n "$src_line" ] || continue
+            source_repo=$(printf '%s' "$src_line" | cut -d'|' -f2)
+            source_path=$(printf '%s' "$src_line" | cut -d'|' -f3 | sed 's|/$||')
+            [ -n "$source_repo" ] || continue
+
+            # Fetch the last 5 unique GitHub logins who committed to this
+            # skill path in the source repo. Falls back to empty (no mentions)
+            # if the repo is private, the API call fails, or all commits are
+            # from bots with no linked GitHub account.
+            logins=$(gh api \
+              "repos/$source_repo/commits?path=$source_path&per_page=5" \
+              --jq '[.[].author.login // empty] | map(select(length > 0)) | unique | .[]' \
+              2>/dev/null || true)
+
+            mentions=$(printf '%s\n' "$logins" | grep -v '^$' \
+                         | awk '{printf "@%s ", $1}' | sed 's/ *$//' || true)
+
+            line="- [\`$dir\`](https://github.com/${{ github.repository }}/tree/main/$dir)"
+            line="$line ([source: $source_repo](https://github.com/$source_repo))"
+            line="$line — ${reason#*: }"
+            [ -n "$mentions" ] && line="$line — cc $mentions"
+            new_lines="${new_lines}${line}"$'\n'
+          done < "$dropped"
+
+          [ -n "$new_lines" ] || exit 0
+
+          # Post one aggregated comment so owners get a single notification.
+          # Write to a temp file to avoid heredoc/YAML quoting issues.
+          ping_body=/tmp/ping-comment-body.md
+          {
+            echo "### New skill drops this sync run — action required"
+            echo ""
+            echo "The following skills were dropped or reverted for the **first time** in this sync run. Each team listed below needs to re-sign before the skill update can land in the catalog."
+            echo ""
+            printf '%s\n' "$new_lines"
+            echo "**How to fix:** run \`/nvskills-ci\` on a follow-up PR in the source repo after updating the skill content. The next sync will pick up the refreshed \`skill.oms.sig\` and include the update automatically."
+            echo ""
+            echo "See [this issue's description](https://github.com/${{ github.repository }}/issues/${issue_num}) for full details on each failure mode."
+          } > "$ping_body"
+          gh issue comment "$issue_num" --body-file "$ping_body"
+          echo "Posted owner-ping comment on issue #$issue_num"
 
       - name: Rebuild plugin catalog
         run: |


### PR DESCRIPTION
## Summary

Automates the manual pinging of source-repo teams when their skill updates are held back by the sync workflow.

### What changes

Three additions to `sync-skills.yml`:

1. **Source map** — during the rsync loop, every successfully rsynced skill records `catalog_dir|source_repo|source_path` to `/tmp/skill-source-map.txt` (before `.tmp` clones are deleted).

2. **Snapshot step** (before Track) — saves the current rolling issue body to a file so the ping step can distinguish new drops from ones already tracked in prior runs.

3. **Ping step** (after Track) — for each *newly* dropped skill:
   - Looks up the source repo + path from the map
   - Calls `gh api repos/<source_repo>/commits?path=<skill_path>&per_page=5` to get the last GitHub logins who touched that skill
   - Posts **one aggregated comment** on the rolling issue with @mentions for all affected owners

### Outcome

When a skill drops for the first time, the owners of that skill in the source repo get a GitHub notification pointing them to the rolling tracker issue with clear recovery instructions (`/nvskills-ci`). They are **not** re-pinged on subsequent sync runs while the skill stays broken — only on the first occurrence.

Closes the manual-ping gap in NVIDIA/skills#216.